### PR TITLE
fix: return api zod errors as proper json

### DIFF
--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -31,7 +31,7 @@ export const apiRouterFactory = <Context extends Record<string, unknown>>(
       try {
         parsedInput = Input.parse(input);
       } catch (error) {
-        res.status(400).json({ error: 'Invalid request data', details: error });
+        res.status(400).json({ error: 'zod validation failure', issues: (error as z.ZodError).issues });
         return;
       }
       const result = await tool.fn(parsedInput);


### PR DESCRIPTION
PR fixes a bug where now on sending invalid payload to an API endpoint, we will send back a 400 error with proper JSON data. Before, we'd send back a generic 500 error (due to uncaught ZodError from `Input.parse`) with the zod error payload being sent back as escaped JSON string. We were also logging this error, which isn't useful imo given it's a user error, and not something going wrong in the server itself.

Before:

```json
{
  "error": "[\n  {\n    \"code\": \"invalid_type\",\n    \"expected\": \"string\",\n    \"received\": \"undefined\",\n    \"path\": [\n      \"key\"\n    ],\n    \"message\": \"Required\"\n  }\n]"
}
```

After:

```json
{
  "error": "zod validation failure",
  "issues": [
    {
      "code": "invalid_type",
      "expected": "string",
      "received": "undefined",
      "path": [
        "key"
      ],
      "message": "Required"
    }
  ],
}
```