### PR TITLE
feat: implement MCP session resilience and environment alignment

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -59,7 +59,7 @@ export const sdk = new NodeSDK({
   spanProcessors,
   logRecordProcessors,
   resource: resourceFromAttributes({
-    'deployment.environment.name': process.env.NODE_ENV || 'development',
+    'deployment.environment.name': process.env.LOGFIRE_ENVIRONMENT || process.env.NODE_ENV || 'development',
     'service.instance.id': process.env.HOSTNAME,
   }),
 });


### PR DESCRIPTION
  Submodule changes (mcp/src/shared/boilerplate):
  - Fix HTTP transport to handle stale session IDs gracefully after server restarts
  - Treat stale sessions as new initialization requests instead of rejecting them
  - Add detailed logging for session recovery debugging
  - Update OpenTelemetry resource config to prioritize LOGFIRE_ENVIRONMENT over NODE_ENV
  - Improve Claude Code MCP client compatibility with containerized servers

  Resolves "No valid session ID provided" errors and enables proper trace correlation
  across Python app and MCP server in unified Logfire environment.

  🤖 Generated with [Claude Code](https://claude.ai/code)

  Co-Authored-By: Claude <noreply@anthropic.com>