### PR TITLE
feat: separate out handling of stateful and stateless request setups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@opentelemetry/sdk-node": "^0.203.0",
         "@opentelemetry/sdk-trace-node": "^2.0.1",
         "express": "^5.1.0",
+        "raw-body": "^3.0.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -4816,18 +4817,34 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
+        "iconv-lite": "0.7.0",
         "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@opentelemetry/sdk-node": "^0.203.0",
     "@opentelemetry/sdk-trace-node": "^2.0.1",
     "express": "^5.1.0",
+    "raw-body": "^3.0.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/httpServer.ts
+++ b/src/httpServer.ts
@@ -17,6 +17,7 @@ export const httpServerFactory = <Context extends Record<string, unknown>>({
   apiFactories,
   additionalSetup,
   cleanupFn,
+  stateful = false,
 }: {
   name: string;
   version?: string;
@@ -24,6 +25,7 @@ export const httpServerFactory = <Context extends Record<string, unknown>>({
   apiFactories: readonly ApiFactory<Context, any, any>[];
   additionalSetup?: (args: AdditionalSetupArgs<Context>) => void;
   cleanupFn?: () => void | Promise<void>;
+  stateful?: boolean;
 }): {
   app: express.Express;
   server: Server;
@@ -40,14 +42,17 @@ export const httpServerFactory = <Context extends Record<string, unknown>>({
 
   const app = express();
 
-  const [mcpRouter, mcpCleanup] = mcpRouterFactory(context, () =>
-    mcpServerFactory({
-      name,
-      version,
-      context,
-      apiFactories,
-      additionalSetup,
-    }),
+  const [mcpRouter, mcpCleanup] = mcpRouterFactory(
+    context,
+    () =>
+      mcpServerFactory({
+        name,
+        version,
+        context,
+        apiFactories,
+        additionalSetup,
+      }),
+    stateful,
   );
   cleanupFns.push(mcpCleanup);
   app.use('/mcp', mcpRouter);


### PR DESCRIPTION
PR updates the HTTP handler logic to better deal with stateful or stateless request setups per the [transport MCP spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports). A server, at configuration time, may declare itself stateless or stateful by setting the `stateful` key on the `httpServerFactory` method, where it defaults to false (stateless).

When a server is running as stateless, then any POST request creates a new transport, handles the request, and once the request is done, closes the transport. Any GET or DELETE request is rejected as they're not supported under stateless (as they're only used for bidirectional communication.

When a server is running in stateful mode, then:
1. When the server receives a POST request, then:
	1. If the request does not have a session id, then: 
		1. If the request is an initialization one (`method: initialize`), then create a new transport (which will handle session id creation and saving the transport into our map) and use that to handle the request
		2. Otherwise return a 400 error for invalid request
	2. If the server receives a request that does have a session id, then:
		1. If the transport for that session, then return 404 error, to indicate that the client should restart their session with a fresh initialization request
		2. Otherwise, use the stored transport for that session id to handle the request
2. When the server receives a GET or DELETE request:
	1. If not session id is present, return 400 error
	2. If session id is present, but is invalid, return a 404 error
	3. If session id is present and valid, then have transport handle the request 

----

I tested both modes with claude code with restarting the server after I use a tool, and I found that:
1. With stateless, each request works as expected and completes.
2. With stateful, after the restart and getting a 404 error, claude will respond with something like "The tiger-memory system is disconnected again. You'll need to reconnect it before I can check your memories.", where then need to do `/mcp restart ...`. Unfortunate that it doesn't auto-reconnect, but :shrug:

For (2), this is better than current behavior where you get:

```
tiger-memory - getMemories (MCP)(key: "user")
  ⎿  Error: Error POSTing to endpoint (HTTP 400): {"jsonrpc":"2.0","error":{"code":-32000,"message":"Bad Request: No valid session ID provided"}}
```