### PR TITLE
fix: run mcp httpServer as stateful by default

### DIFF
--- a/src/http/mcp.ts
+++ b/src/http/mcp.ts
@@ -10,7 +10,7 @@ import { log } from '../logger.js';
 export const mcpRouterFactory = <Context extends Record<string, unknown>>(
   context: Context,
   createServer: (context: Context) => { server: McpServer },
-  stateful = false,
+  stateful = true,
 ): RouterFactoryResult => {
   const router = Router();
 

--- a/src/httpServer.ts
+++ b/src/httpServer.ts
@@ -17,7 +17,7 @@ export const httpServerFactory = <Context extends Record<string, unknown>>({
   apiFactories,
   additionalSetup,
   cleanupFn,
-  stateful = false,
+  stateful = true,
 }: {
   name: string;
   version?: string;


### PR DESCRIPTION
This PR modifies the MCP httpServer to be stateful by default. We made them stateless by default with #7, but I'm finding some agents are now hitting 405 errors on trying to do `GET` requests which was surprising to me that any are using that functionality.

Given this, I think it makes sense to run the servers in a stateful setup by default and that someone can optionally opt into running it stateless after consideration of the agent's behavior and that it only issues POST requests.