### PR TITLE
[AGE-486] Add migrations logic

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "@tigerdata/mcp-boilerplate",
@@ -18,6 +17,8 @@
         "@toon-format/toon": "^2.1.0",
         "express": "^5.2.1",
         "gray-matter": "^4.0.3",
+        "migrate": "^2.1.0",
+        "pg": "^8.16.3",
         "raw-body": "^3.0.2",
         "yaml": "^2.8.2",
       },
@@ -847,7 +848,7 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
-    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+    "commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -873,6 +874,8 @@
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
+    "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
@@ -897,7 +900,7 @@
 
     "dompurify": ["dompurify@3.3.3", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA=="],
 
-    "dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
+    "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -1205,6 +1208,8 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "migrate": ["migrate@2.1.0", "", { "dependencies": { "chalk": "^4.1.2", "commander": "^2.20.3", "dateformat": "^4.6.3", "dotenv": "^16.0.0", "inherits": "^2.0.3", "minimatch": "^9.0.1", "mkdirp": "^3.0.1", "slug": "^8.2.2" }, "bin": { "migrate": "bin/migrate", "migrate-up": "bin/migrate-up", "migrate-down": "bin/migrate-down", "migrate-init": "bin/migrate-init", "migrate-list": "bin/migrate-list", "migrate-create": "bin/migrate-create" } }, "sha512-xSwTScy7ozxQtzDtO/LpmZzWTmItXBC3k3wOQGf8TjHpudQUS/m7uyboBHHsv2nFmioyyC7gtbcI7IPj89aJLA=="],
+
     "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
@@ -1216,6 +1221,8 @@
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
+    "mkdirp": ["mkdirp@3.0.1", "", { "bin": { "mkdirp": "dist/cjs/src/bin.js" } }, "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="],
 
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
@@ -1293,11 +1300,21 @@
 
     "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
+    "pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.3.0", "", {}, "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="],
+
+    "pg-connection-string": ["pg-connection-string@2.12.0", "", {}, "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ=="],
+
     "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
 
-    "pg-protocol": ["pg-protocol@1.11.0", "", {}, "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g=="],
+    "pg-pool": ["pg-pool@3.13.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA=="],
+
+    "pg-protocol": ["pg-protocol@1.13.0", "", {}, "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w=="],
 
     "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -1425,11 +1442,15 @@
 
     "slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
 
+    "slug": ["slug@8.2.3", "", { "bin": { "slug": "cli.js" } }, "sha512-fXjhAZszNecz855GUNIwW0+sFPi9WV4bMiEKDOCA4wcq1ts1UnUVNy/F78B0Aat7/W3rA+se//33ILKNMrbeYQ=="],
+
     "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
@@ -1567,6 +1588,10 @@
 
     "@mcp-use/cli/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "@mcp-use/cli/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "@mcp-use/cli/dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
+
     "@mcp-use/cli/esbuild": ["esbuild@0.27.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.1", "@esbuild/android-arm": "0.27.1", "@esbuild/android-arm64": "0.27.1", "@esbuild/android-x64": "0.27.1", "@esbuild/darwin-arm64": "0.27.1", "@esbuild/darwin-x64": "0.27.1", "@esbuild/freebsd-arm64": "0.27.1", "@esbuild/freebsd-x64": "0.27.1", "@esbuild/linux-arm": "0.27.1", "@esbuild/linux-arm64": "0.27.1", "@esbuild/linux-ia32": "0.27.1", "@esbuild/linux-loong64": "0.27.1", "@esbuild/linux-mips64el": "0.27.1", "@esbuild/linux-ppc64": "0.27.1", "@esbuild/linux-riscv64": "0.27.1", "@esbuild/linux-s390x": "0.27.1", "@esbuild/linux-x64": "0.27.1", "@esbuild/netbsd-arm64": "0.27.1", "@esbuild/netbsd-x64": "0.27.1", "@esbuild/openbsd-arm64": "0.27.1", "@esbuild/openbsd-x64": "0.27.1", "@esbuild/openharmony-arm64": "0.27.1", "@esbuild/sunos-x64": "0.27.1", "@esbuild/win32-arm64": "0.27.1", "@esbuild/win32-ia32": "0.27.1", "@esbuild/win32-x64": "0.27.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA=="],
 
     "@mcp-use/cli/zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
@@ -1609,6 +1634,8 @@
 
     "@types/pg/@types/node": ["@types/node@22.19.8", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ebO/Yl+EAvVe8DnMfi+iaAyIqYdK0q/q0y0rw82INWEKJOBe6b/P3YWE8NW7oOlF/nXFNrHwhARrN/hdgDkraA=="],
 
+    "@types/pg/pg-protocol": ["pg-protocol@1.11.0", "", {}, "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g=="],
+
     "@types/send/@types/node": ["@types/node@22.19.8", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ebO/Yl+EAvVe8DnMfi+iaAyIqYdK0q/q0y0rw82INWEKJOBe6b/P3YWE8NW7oOlF/nXFNrHwhARrN/hdgDkraA=="],
 
     "@types/serve-static/@types/node": ["@types/node@22.19.8", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ebO/Yl+EAvVe8DnMfi+iaAyIqYdK0q/q0y0rw82INWEKJOBe6b/P3YWE8NW7oOlF/nXFNrHwhARrN/hdgDkraA=="],
@@ -1638,6 +1665,8 @@
     "mcp-use/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "migrate/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "node-mocks-http/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
@@ -1745,6 +1774,8 @@
 
     "express-static-gzip/serve-static/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
 
+    "migrate/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
     "node-mocks-http/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "node-mocks-http/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
@@ -1772,6 +1803,8 @@
     "express-static-gzip/serve-static/send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "express-static-gzip/serve-static/send/fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
+    "migrate/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "node-mocks-http/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
     "express": "^5.2.1",
     "gray-matter": "^4.0.3",
     "raw-body": "^3.0.2",
-    "yaml": "^2.8.2"
+    "yaml": "^2.8.2",
+    "migrate": "^2.1.0",
+    "pg": "^8.16.3"
   },
   "peerDependencies": {
     "zod": "^3.25 || ^4.0"

--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",
+    "migrate": "^2.1.0",
+    "pg": "^8.16.3",
     "zod": "^4.3.6",
     "@octokit/rest": "^22.0.1",
     "@types/bun": "^1.3.10",

--- a/package.json
+++ b/package.json
@@ -55,12 +55,20 @@
     "express": "^5.2.1",
     "gray-matter": "^4.0.3",
     "raw-body": "^3.0.2",
-    "yaml": "^2.8.2",
-    "migrate": "^2.1.0",
-    "pg": "^8.16.3"
+    "yaml": "^2.8.2"
   },
   "peerDependencies": {
+    "migrate": "^2.1.0",
+    "pg": "^8.16.3",
     "zod": "^3.25 || ^4.0"
+  },
+  "peerDependenciesMeta": {
+    "migrate": {
+      "optional": true
+    },
+    "pg": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",

--- a/src/cliEntrypoint.ts
+++ b/src/cliEntrypoint.ts
@@ -1,8 +1,7 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { runMigrations } from './migrate.js';
-import type { DatabaseConfiguration } from './types.js';
 import { log } from './logger.js';
+import type { DatabaseConfiguration } from './types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -17,6 +16,7 @@ export async function cliEntrypoint(
   const scriptName = args[0] || 'stdio';
   try {
     if (dbConfig) {
+      const { runMigrations } = await import('./migrate.js');
       log.info('starting server...');
       try {
         log.info('Running database migrations...');

--- a/src/cliEntrypoint.ts
+++ b/src/cliEntrypoint.ts
@@ -1,7 +1,7 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { log } from './logger.js';
-import type { DatabaseConfiguration } from './types.js';
+import type { MigrationsConfig } from './types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -9,7 +9,7 @@ export async function cliEntrypoint(
   stdioEntrypoint: string,
   httpEntrypoint: string,
   instrumentation = join(__dirname, './instrumentation.js'),
-  dbConfig?: DatabaseConfiguration,
+  dbConfig?: MigrationsConfig,
 ): Promise<void> {
   // Parse command line arguments first
   const args = process.argv.slice(2);

--- a/src/cliEntrypoint.ts
+++ b/src/cliEntrypoint.ts
@@ -16,11 +16,11 @@ export async function cliEntrypoint(
   const scriptName = args[0] || 'stdio';
   try {
     if (dbConfig) {
-      const { runMigrations } = await import('./migrate.js');
+      const { createMigrator } = await import('./migrate.js');
       log.info('starting server...');
       try {
         log.info('Running database migrations...');
-        await runMigrations(dbConfig);
+        await createMigrator(dbConfig).run();
         log.info('Database migrations completed successfully');
       } catch (error) {
         log.error('Database migration failed:', error as Error);

--- a/src/cliEntrypoint.ts
+++ b/src/cliEntrypoint.ts
@@ -1,5 +1,7 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { runMigrations } from './migrate.js';
+import type { DatabaseConfiguration } from './types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -7,12 +9,18 @@ export async function cliEntrypoint(
   stdioEntrypoint: string,
   httpEntrypoint: string,
   instrumentation = join(__dirname, './instrumentation.js'),
+  dbConfig?: DatabaseConfiguration,
 ): Promise<void> {
   // Parse command line arguments first
   const args = process.argv.slice(2);
   const scriptName = args[0] || 'stdio';
   try {
     // Dynamically import only the requested module to prevent all modules from initializing
+    if (dbConfig) {
+      console.log('Database configuration received', dbConfig);
+
+      await runMigrations(dbConfig);
+    }
     switch (scriptName) {
       case 'stdio': {
         // Import and run the stdio server

--- a/src/cliEntrypoint.ts
+++ b/src/cliEntrypoint.ts
@@ -2,6 +2,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { runMigrations } from './migrate.js';
 import type { DatabaseConfiguration } from './types.js';
+import { log } from './logger.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -15,12 +16,19 @@ export async function cliEntrypoint(
   const args = process.argv.slice(2);
   const scriptName = args[0] || 'stdio';
   try {
-    // Dynamically import only the requested module to prevent all modules from initializing
     if (dbConfig) {
-      console.log('Database configuration received', dbConfig);
-
-      await runMigrations(dbConfig);
+      log.info('starting server...');
+      try {
+        log.info('Running database migrations...');
+        await runMigrations(dbConfig);
+        log.info('Database migrations completed successfully');
+      } catch (error) {
+        log.error('Database migration failed:', error as Error);
+        throw error;
+      }
     }
+
+    // Dynamically import only the requested module to prevent all modules from initializing
     switch (scriptName) {
       case 'stdio': {
         // Import and run the stdio server

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { cliEntrypoint } from './cliEntrypoint.js';
 export { httpServerFactory } from './httpServer.js';
 export { log } from './logger.js';
 export type { AdditionalSetupArgs } from './mcpServer.js';
+export { createMigrator } from './migrate.js';
 export { registerExitHandlers } from './registerExitHandlers.js';
 export { StatusError } from './StatusError.js';
 export { stdioServerFactory } from './stdio.js';

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import type { FileStore, MigrationSet } from 'migrate';
 import migrate from 'migrate';
 import { Client } from 'pg';

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,0 +1,113 @@
+import { createHash } from 'crypto';
+import type { FileStore, MigrationSet } from 'migrate';
+import migrate from 'migrate';
+import { Client } from 'pg';
+import type { DatabaseConfiguration } from './types.js';
+
+// Use a hash of the project name
+const hash = createHash('sha256')
+  .update('tiger-memory-mcp-server')
+  .digest('hex');
+const MIGRATION_ADVISORY_LOCK_ID = parseInt(hash.substring(0, 15), 16);
+
+interface Store extends FileStore {
+  close(): Promise<void>;
+}
+
+const createStateStore = (schema: string): Store => {
+  let client: Client;
+
+  return {
+    async load(callback: Parameters<FileStore['load']>[0]): Promise<void> {
+      try {
+        client = new Client();
+        await client.connect();
+
+        // Acquire advisory lock to prevent concurrent migrations
+        await client.query(/* sql */ `SELECT pg_advisory_lock($1)`, [
+          MIGRATION_ADVISORY_LOCK_ID,
+        ]);
+
+        // Ensure migrations table exists
+        await client.query(/* sql */ `
+          CREATE SCHEMA IF NOT EXISTS ${schema};
+
+          CREATE TABLE IF NOT EXISTS ${schema}.migrations (
+            id SERIAL PRIMARY KEY,
+            set JSONB NOT NULL,
+            applied_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+          );
+        `);
+
+        // Load the most recent migration set
+        const result = await client.query(
+          /* sql */ `SELECT set FROM ${schema}.migrations ORDER BY applied_at DESC LIMIT 1`,
+        );
+
+        const set = result.rows.length > 0 ? result.rows[0].set : {};
+        callback(null, set);
+      } catch (error) {
+        callback(error as Error);
+      }
+    },
+
+    async save(
+      set: MigrationSet,
+      callback: (err: Error | null) => void,
+    ): Promise<void> {
+      try {
+        // Insert the entire set as JSONB
+        await client.query(
+          /* sql */ `INSERT INTO ${schema}.migrations (set) VALUES ($1)`,
+          [JSON.stringify(set)],
+        );
+
+        callback(null);
+      } catch (error) {
+        callback(error as Error);
+      }
+    },
+
+    async close(): Promise<void> {
+      if (client) {
+        // Release advisory lock
+        await client.query(/* sql */ `SELECT pg_advisory_unlock($1)`, [
+          MIGRATION_ADVISORY_LOCK_ID,
+        ]);
+        await client.end();
+      }
+    },
+  };
+};
+
+export const runMigrations = async (
+  config: DatabaseConfiguration,
+): Promise<void> => {
+  const { schema, migrationsDirectory } = config;
+  return new Promise((resolve, reject) => {
+    const stateStore = createStateStore(schema);
+
+    migrate.load(
+      {
+        stateStore,
+        migrationsDirectory: migrationsDirectory,
+      },
+      (err, set) => {
+        if (err) {
+          stateStore.close().finally(() => reject(err));
+          return;
+        }
+
+        set.up((err) => {
+          stateStore.close().finally(() => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve();
+            }
+          });
+        });
+      },
+    );
+  });
+};

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -8,7 +8,7 @@ interface Store extends FileStore {
   close(): Promise<void>;
 }
 
-const createStateStore = (name: string, schema: string): Store => {
+const createStateStore = (name: string, schema: string = 'public'): Store => {
   let client: Client;
 
   // Use a hash of the project name to create a lock
@@ -78,34 +78,34 @@ const createStateStore = (name: string, schema: string): Store => {
   };
 };
 
-export const runMigrations = async (
-  config: MigrationsConfig,
-): Promise<void> => {
+export const createMigrator = (config: MigrationsConfig) => {
   const { schema, migrationsDirectory, serviceName } = config;
-  return new Promise((resolve, reject) => {
-    const stateStore = createStateStore(serviceName, schema);
-
-    migrate.load(
-      {
-        stateStore,
-        migrationsDirectory: migrationsDirectory,
-      },
-      (err, set) => {
-        if (err) {
-          stateStore.close().finally(() => reject(err));
-          return;
-        }
-
-        set.up((err) => {
-          stateStore.close().finally(() => {
+  const stateStore = createStateStore(serviceName, schema);
+  return {
+    run: async () =>
+      new Promise<void>((resolve, reject) => {
+        migrate.load(
+          {
+            stateStore,
+            migrationsDirectory: migrationsDirectory ?? './migrations',
+          },
+          (err, set) => {
             if (err) {
-              reject(err);
-            } else {
-              resolve();
+              stateStore.close().finally(() => reject(err));
+              return;
             }
-          });
-        });
-      },
-    );
-  });
+
+            set.up((err) => {
+              stateStore.close().finally(() => {
+                if (err) {
+                  reject(err);
+                } else {
+                  resolve();
+                }
+              });
+            });
+          },
+        );
+      }),
+  };
 };

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -10,13 +10,12 @@ interface Store extends FileStore {
 
 const createStateStore = (name: string, schema: string): Store => {
   let client: Client;
+  // Use a hash of the project name to create a lock
 
+  const hash = createHash('sha256').update(name).digest('hex');
+  const advisoryLockId = parseInt(hash.substring(0, 15), 16);
   return {
     async load(callback: Parameters<FileStore['load']>[0]): Promise<void> {
-      // Use a hash of the project name to create a lock
-      const hash = createHash('sha256').update(name).digest('hex');
-      const advisoryLockId = parseInt(hash.substring(0, 15), 16);
-
       try {
         client = new Client();
         await client.connect();
@@ -70,7 +69,7 @@ const createStateStore = (name: string, schema: string): Store => {
       if (client) {
         // Release advisory lock
         await client.query(/* sql */ `SELECT pg_advisory_unlock($1)`, [
-          MIGRATION_ADVISORY_LOCK_ID,
+          advisoryLockId,
         ]);
         await client.end();
       }

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -10,10 +10,11 @@ interface Store extends FileStore {
 
 const createStateStore = (name: string, schema: string): Store => {
   let client: Client;
-  // Use a hash of the project name to create a lock
 
+  // Use a hash of the project name to create a lock
   const hash = createHash('sha256').update(name).digest('hex');
   const advisoryLockId = parseInt(hash.substring(0, 15), 16);
+
   return {
     async load(callback: Parameters<FileStore['load']>[0]): Promise<void> {
       try {

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -2,30 +2,28 @@ import { createHash } from 'node:crypto';
 import type { FileStore, MigrationSet } from 'migrate';
 import migrate from 'migrate';
 import { Client } from 'pg';
-import type { DatabaseConfiguration } from './types.js';
-
-// Use a hash of the project name
-const hash = createHash('sha256')
-  .update('tiger-memory-mcp-server')
-  .digest('hex');
-const MIGRATION_ADVISORY_LOCK_ID = parseInt(hash.substring(0, 15), 16);
+import type { MigrationsConfig } from './types.js';
 
 interface Store extends FileStore {
   close(): Promise<void>;
 }
 
-const createStateStore = (schema: string): Store => {
+const createStateStore = (name: string, schema: string): Store => {
   let client: Client;
 
   return {
     async load(callback: Parameters<FileStore['load']>[0]): Promise<void> {
+      // Use a hash of the project name to create a lock
+      const hash = createHash('sha256').update(name).digest('hex');
+      const advisoryLockId = parseInt(hash.substring(0, 15), 16);
+
       try {
         client = new Client();
         await client.connect();
 
         // Acquire advisory lock to prevent concurrent migrations
         await client.query(/* sql */ `SELECT pg_advisory_lock($1)`, [
-          MIGRATION_ADVISORY_LOCK_ID,
+          advisoryLockId,
         ]);
 
         // Ensure migrations table exists
@@ -81,11 +79,11 @@ const createStateStore = (schema: string): Store => {
 };
 
 export const runMigrations = async (
-  config: DatabaseConfiguration,
+  config: MigrationsConfig,
 ): Promise<void> => {
-  const { schema, migrationsDirectory } = config;
+  const { schema, migrationsDirectory, serviceName } = config;
   return new Promise((resolve, reject) => {
-    const stateStore = createStateStore(schema);
+    const stateStore = createStateStore(serviceName, schema);
 
     migrate.load(
       {

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,7 +184,8 @@ export type InferSchema<T extends Record<string, z.ZodType>> = Flatten<
   }
 >;
 
-export interface DatabaseConfiguration {
+export interface MigrationsConfig {
+  serviceName: string;
   migrationsDirectory: string;
   schema: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,6 +186,6 @@ export type InferSchema<T extends Record<string, z.ZodType>> = Flatten<
 
 export interface MigrationsConfig {
   serviceName: string;
-  migrationsDirectory: string;
-  schema: string;
+  migrationsDirectory?: string;
+  schema?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,3 +183,8 @@ export type InferSchema<T extends Record<string, z.ZodType>> = Flatten<
     [K in OptionalKeys<T>]?: z.infer<T[K]>;
   }
 >;
+
+export interface DatabaseConfiguration {
+  migrationsDirectory: string;
+  schema: string;
+}


### PR DESCRIPTION
## What 
This adds the migration logic from [tiger-memory-mcp-server](https://github.com/timescale/tiger-memory-mcp-server/blob/main/src/migrate.ts) so that we can DRY up our MCP servers that are DB wrappers.

Note: this migration logic is conditional on passing in a `DatabaseConfiguration` into the `cliEntryPoint`.

## Testing
In `pg-ai-guide`, tested like so:

```typescript
cliEntrypoint(
  join(__dirname, 'stdio.js'),
  join(__dirname, 'httpServer.js'),
  undefined,
  { schema: schema, migrationsDirectory: './migrations', serviceName: 'pg-aiguide' },
).catch(console.error);
```

Runtime logs:
```
Debugger attached.
starting server...
Running database migrations...
Database migrations completed successfully
HTTP Server listening on port 5571
🌐 MCP inspector running at http://localhost:5571/inspector
```

And the pudding:
<img width="246" height="256" alt="image" src="https://github.com/user-attachments/assets/4dc0ed17-dd67-4f33-b3a9-d2d792620a48" />
