### PR TITLE
Prevent bun installer from modifying shell config

### DIFF
--- a/bun
+++ b/bun
@@ -10,7 +10,11 @@ if [ ! -f "$bunCmd" ]; then
     if [ "$version" != "latest" ]; then
         bashArgs=(-s "$version")
     fi
-    curl -fsSL https://bun.sh/install | BUN_INSTALL="$downloadDir" bash "${bashArgs[@]}"
+    # Override SHELL so the installer's `case $(basename "$SHELL")` falls through
+    # to its default branch, which only prints manual instructions instead of
+    # appending BUN_INSTALL/PATH exports to ~/.bashrc (or .zshrc / config.fish).
+    # We invoke bun via its explicit path, so we don't need those PATH edits.
+    curl -fsSL https://bun.sh/install | SHELL="" BUN_INSTALL="$downloadDir" bash "${bashArgs[@]}"
 fi
 
 exec "$bunCmd" "$@"


### PR DESCRIPTION
## Summary

The `bun` bootstrap script downloads and runs the official bun installer (`https://bun.sh/install`). That installer has an unwanted side-effect: it appends `BUN_INSTALL` and `PATH` exports to the user's shell config (`~/.bashrc`, `~/.zshrc`, or `config.fish`).

## Investigation

The installer has **no dedicated flag/env var** to disable shell-config modification. The behavior is gated by a `case $(basename "$SHELL")` switch — it only appends to a config file when the shell basename matches `fish`, `zsh`, or `bash`. The default `*)` branch merely prints manual instructions and writes nothing.

## Fix

Pass `SHELL=""` when piping into the installer so its `case` falls through to the harmless default branch. Since the wrapper always invokes bun via its explicit path, the `PATH` exports were never needed anyway.
