### PR TITLE
Bump version from 1.3.5 to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tigerdata/mcp-boilerplate",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "description": "MCP boilerplate code for Node.js",
   "license": "Apache-2.0",
   "author": "TigerData",


### PR DESCRIPTION
Releases the ref field added in #36 to npm. Tag v1.4.0