### PR TITLE
Add opt-in DNS rebinding protection and interface binding to HTTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,45 @@ npm install @tigerdata/mcp-boilerplate
 
 See [tiger-skills-mcp-server](https://github.com/tigerdata/tiger-skills-mcp-server) for an example MCP server using this boilerplate.
 
+### DNS Rebinding Protection
+
+MCP servers reachable over HTTP can be targeted by [DNS rebinding attacks](https://en.wikipedia.org/wiki/DNS_rebinding), where a malicious website bypasses the browser same-origin policy by pointing a domain at a localhost (or otherwise private) address to reach a local server. The MCP SDK guards against this by validating the `Host` header against an allow-list.
+
+This check is **most useful for localhost / development servers** without HTTPS or authentication. Hosted servers served on public hostnames generally don't need it (and would reject legitimate traffic unless every allowed hostname is listed), so `httpServerFactory` leaves it **disabled by default** — it is opt-in via the `dnsRebindingProtection` option (scoped to the MCP and API mount paths):
+
+```ts
+import { httpServerFactory } from '@tigerdata/mcp-boilerplate';
+
+await httpServerFactory({
+  name: 'my-server',
+  context,
+  // Omitted (default): disabled, UNLESS MCP_ALLOWED_HOSTS is set — in which
+  //   case protection is enabled using that env var's allow-list.
+  // true: enabled. Uses the MCP_ALLOWED_HOSTS allow-list when set, otherwise
+  //   localhost-only (localhost, 127.0.0.1, [::1]).
+  // string[]: enabled with this exact allow-list (MCP_ALLOWED_HOSTS ignored).
+  //   Hostnames only, without ports; use [::1] for IPv6.
+  // false: disabled. Always wins, even if MCP_ALLOWED_HOSTS is set.
+  dnsRebindingProtection: true,
+});
+```
+
+The `MCP_ALLOWED_HOSTS` environment variable can both enable and configure protection without touching code: set it to a comma-separated list of hostnames (e.g. `localhost,127.0.0.1,[::1]`) and protection turns on using that list. It is consulted whenever `dnsRebindingProtection` is omitted or `true`, but is ignored when an explicit `string[]` is passed (that list wins) or when `false` is passed (protection stays off).
+
+### Binding to a specific network interface
+
+Separately from Host header validation, you can restrict which network interface the server's socket accepts connections on via the `host` option (forwarded to `app.listen()`). Binding to loopback is an OS-level defense that makes the port unreachable from other machines entirely — useful for localhost/development servers:
+
+```ts
+await httpServerFactory({
+  name: 'my-server',
+  context,
+  host: '127.0.0.1', // only accept connections on loopback
+});
+```
+
+Defaults to the `HOST` environment variable, or all available interfaces when unset. This is independent of `dnsRebindingProtection` and is ignored when an external `app` is provided (the caller owns the server lifecycle).
+
 ### Skills
 
 Add skills support to your MCP server by leveraging the skills submodule in `@tigerdata/mcp-boilerplate/skills`. See the [Skills README](./src/skills/README.md) for details.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "prepublishOnly": "tsc",
     "watch": "tsc --watch",
     "lint": "./bun x @biomejs/biome check",
-    "test": "./bun test ./src"
+    "test": "./bun test ./src",
+    "check": "tsc --noEmit && ./bun --silent lint --write && ./bun --silent run test --only-failures"
   },
   "dependencies": {
     "@mcp-use/inspector": "^10.0.1",

--- a/src/httpServer.spec.ts
+++ b/src/httpServer.spec.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import express from 'express';
+import { httpServerFactory } from './httpServer.js';
+
+interface StartedServer {
+  port: number;
+  cleanup: () => Promise<void>;
+}
+
+const startServer = async (
+  dnsRebindingProtection: boolean | readonly string[] | undefined,
+): Promise<StartedServer> => {
+  const app = express();
+  await httpServerFactory({
+    name: 'test-server',
+    context: {},
+    app,
+    dnsRebindingProtection,
+  });
+
+  const server = app.listen(0);
+  await new Promise<void>((resolve) => server.once('listening', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected a TCP server address');
+  }
+
+  return {
+    port: address.port,
+    cleanup: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+};
+
+const postMcp = (port: number, host: string | undefined): Promise<Response> => {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    accept: 'application/json, text/event-stream',
+  };
+  if (host !== undefined) {
+    headers.host = host;
+  }
+  // Use 127.0.0.1 so the request reaches the server, while overriding the
+  // Host header to exercise validation.
+  return fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'test', version: '1.0.0' },
+      },
+    }),
+  });
+};
+
+describe('httpServerFactory DNS rebinding protection', () => {
+  const started: StartedServer[] = [];
+
+  afterEach(async () => {
+    while (started.length > 0) {
+      const s = started.pop();
+      await s?.cleanup();
+    }
+  });
+
+  const track = (s: StartedServer): StartedServer => {
+    started.push(s);
+    return s;
+  };
+
+  it('rejects disallowed Host headers when protection is enabled', async () => {
+    const { port } = track(await startServer(true));
+
+    const res = await postMcp(port, 'evil.example.com');
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error?: { message?: string } };
+    expect(body.error?.message).toContain('Invalid Host');
+  });
+
+  it('is disabled by default when the option is omitted', async () => {
+    const { port } = track(await startServer(undefined));
+
+    const res = await postMcp(port, 'evil.example.com');
+    expect(res.status).not.toBe(403);
+  });
+
+  it('allows localhost Host headers when protection is enabled', async () => {
+    const { port } = track(await startServer(true));
+
+    const res = await postMcp(port, `127.0.0.1:${port}`);
+    // Not a 403 — the request passes Host validation and reaches the MCP
+    // handler (which then negotiates the session normally).
+    expect(res.status).not.toBe(403);
+  });
+
+  it('allows any Host header when protection is disabled', async () => {
+    const { port } = track(await startServer(false));
+
+    const res = await postMcp(port, 'evil.example.com');
+    expect(res.status).not.toBe(403);
+  });
+
+  it('validates against a custom allow-list', async () => {
+    const { port } = track(await startServer(['mcp.internal']));
+
+    const allowed = await postMcp(port, 'mcp.internal');
+    expect(allowed.status).not.toBe(403);
+
+    const denied = await postMcp(port, 'localhost');
+    expect(denied.status).toBe(403);
+  });
+});
+
+describe('httpServerFactory interface binding', () => {
+  it('binds to the requested host', async () => {
+    const prevPort = process.env.PORT;
+    process.env.PORT = '0';
+    try {
+      const { server } = await httpServerFactory({
+        name: 'test-server',
+        context: {},
+        host: '127.0.0.1',
+      });
+      if (!server) {
+        throw new Error('Expected own server');
+      }
+      try {
+        if (!server.listening) {
+          await new Promise<void>((resolve, reject) => {
+            server.once('listening', resolve);
+            server.once('error', reject);
+          });
+        }
+        const address = server.address();
+        if (!address || typeof address === 'string') {
+          throw new Error('Expected a TCP server address');
+        }
+        expect(address.address).toBe('127.0.0.1');
+      } finally {
+        await new Promise<void>((resolve, reject) =>
+          server.close((err) => (err ? reject(err) : resolve())),
+        );
+      }
+    } finally {
+      if (prevPort === undefined) {
+        delete process.env.PORT;
+      } else {
+        process.env.PORT = prevPort;
+      }
+    }
+  });
+});

--- a/src/httpServer.ts
+++ b/src/httpServer.ts
@@ -164,7 +164,10 @@ export const httpServerFactory = async <
     app = ownApp;
   }
 
-  const PORT = process.env.PORT || 3001;
+  const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3001;
+  if (!Number.isInteger(PORT) || PORT < 0 || PORT > 65535) {
+    throw new Error(`Invalid PORT environment variable: ${process.env.PORT}`);
+  }
 
   // DNS rebinding protection: validate the Host header against an allow-list.
   // Scoped to the MCP and API mount paths so callers providing an external
@@ -272,11 +275,14 @@ export const httpServerFactory = async <
   // `app.listen` overloads differ by whether a host is provided; calling with
   // an explicit `undefined` host binds all interfaces (Node's default).
   const server = host
-    ? ownApp.listen(Number(PORT), host, onListen)
+    ? ownApp.listen(PORT, host, onListen)
     : ownApp.listen(PORT, onListen);
-  cleanupFns.push(async () => {
-    await server.close();
-  });
+  cleanupFns.push(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  );
 
   return {
     app,

--- a/src/httpServer.ts
+++ b/src/httpServer.ts
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 import type { Server } from 'node:http';
+import { hostHeaderValidation } from '@modelcontextprotocol/sdk/server/middleware/hostHeaderValidation.js';
 import bodyParser from 'body-parser';
 import express, {
   type NextFunction,
   type Request,
+  type RequestHandler,
   type Response,
   type Router,
 } from 'express';
@@ -44,7 +46,80 @@ interface HttpServerOptions<Context extends Record<string, unknown>> {
    * Path to mount the API router at. Defaults to `"/api"`.
    */
   apiPath?: string;
+  /**
+   * DNS rebinding protection via Host header validation. DNS rebinding
+   * attacks can bypass the browser same-origin policy by pointing a domain at
+   * a localhost address, letting a malicious website reach a local server.
+   * Validating the Host header against an allow-list prevents this. This is
+   * especially important for servers without authorization or HTTPS.
+   *
+   * Protection is **disabled by default** (opt-in). This library is primarily
+   * used by hosted MCP servers served on arbitrary public hostnames, where a
+   * Host allow-list would reject legitimate traffic and the DNS rebinding
+   * threat (a victim's browser reaching an unauthenticated `localhost`
+   * server) does not apply. Localhost/development servers should opt in.
+   *
+   * The `MCP_ALLOWED_HOSTS` environment variable (a comma-separated list of
+   * hostnames) is consulted when this option is omitted or `true`, and is
+   * ignored when an explicit `string[]` or `false` is passed:
+   *
+   * - omitted (default): disabled, unless `MCP_ALLOWED_HOSTS` is set — in
+   *   which case protection is enabled using that allow-list.
+   * - `true`: enabled. Uses the `MCP_ALLOWED_HOSTS` allow-list when set,
+   *   otherwise defaults to localhost (`localhost`, `127.0.0.1`, `[::1]`).
+   * - `string[]`: enabled, validating against exactly these hostnames
+   *   (`MCP_ALLOWED_HOSTS` is ignored). Hostnames only, without ports; for
+   *   IPv6, use bracket notation (e.g. `"[::1]"`).
+   * - `false`: disabled. Always wins, even if `MCP_ALLOWED_HOSTS` is set.
+   */
+  dnsRebindingProtection?: boolean | readonly string[];
+  /**
+   * Network interface (hostname or IP address) to bind the HTTP server to.
+   * Forwarded to `app.listen()`. For example, `"127.0.0.1"` restricts the
+   * server to loopback so it is unreachable from other machines — a strong,
+   * OS-level defense for localhost/development servers.
+   *
+   * Defaults to the `HOST` environment variable, or undefined (bind all
+   * available interfaces) when unset. Ignored when an external `app` is
+   * provided, since the caller owns the server lifecycle.
+   */
+  host?: string;
 }
+
+const LOCALHOST_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'];
+
+const hostnamesFromEnv = (): string[] | null => {
+  const fromEnv = process.env.MCP_ALLOWED_HOSTS?.split(',')
+    .map((hostname) => hostname.trim())
+    .filter(Boolean);
+  return fromEnv?.length ? fromEnv : null;
+};
+
+/**
+ * Resolves the Host header allow-list for DNS rebinding protection.
+ * Returns `null` when protection is disabled. Protection is disabled by
+ * default (opt-in); it is enabled by passing `true`, passing an explicit
+ * allow-list, or setting the `MCP_ALLOWED_HOSTS` environment variable.
+ */
+const resolveAllowedHostnames = (
+  dnsRebindingProtection: boolean | readonly string[] | undefined,
+): string[] | null => {
+  // Explicit custom allow-list.
+  if (Array.isArray(dnsRebindingProtection)) {
+    return [...dnsRebindingProtection];
+  }
+  // Explicit opt-out wins over the env var.
+  if (dnsRebindingProtection === false) {
+    return null;
+  }
+  // Explicitly enabled: use the env-configured allow-list when present,
+  // otherwise fall back to localhost-only.
+  if (dnsRebindingProtection === true) {
+    return hostnamesFromEnv() ?? [...LOCALHOST_HOSTNAMES];
+  }
+  // Disabled by default (omitted), unless the env var opts in.
+  return hostnamesFromEnv();
+};
 
 interface HttpServerResult {
   app: Router;
@@ -71,6 +146,8 @@ export const httpServerFactory = async <
   app: externalApp,
   mcpPath = '/mcp',
   apiPath = '/api',
+  dnsRebindingProtection,
+  host = process.env.HOST,
 }: HttpServerOptions<Context>): Promise<HttpServerResult> => {
   const cleanupFns: (() => void | Promise<void>)[] = cleanupFn
     ? [cleanupFn]
@@ -88,6 +165,17 @@ export const httpServerFactory = async <
   }
 
   const PORT = process.env.PORT || 3001;
+
+  // DNS rebinding protection: validate the Host header against an allow-list.
+  // Scoped to the MCP and API mount paths so callers providing an external
+  // app keep full control over their other routes.
+  const allowedHostnames = resolveAllowedHostnames(dnsRebindingProtection);
+  const hostValidation: RequestHandler | null = allowedHostnames
+    ? hostHeaderValidation(allowedHostnames)
+    : null;
+  if (allowedHostnames) {
+    log.info('DNS rebinding protection enabled', { allowedHostnames });
+  }
 
   const inspector =
     process.env.NODE_ENV !== 'production' ||
@@ -110,10 +198,16 @@ export const httpServerFactory = async <
     { name, stateful, inspector },
   );
   cleanupFns.push(mcpCleanup);
+  if (hostValidation) {
+    app.use(mcpPath, hostValidation);
+  }
   app.use(mcpPath, mcpRouter);
 
   const [apiRouter, apiCleanup] = await apiRouterFactory(context, apiFactories);
   cleanupFns.push(apiCleanup);
+  if (hostValidation) {
+    app.use(apiPath, hostValidation);
+  }
   app.use(apiPath, apiRouter);
 
   // Error handler
@@ -160,19 +254,26 @@ export const httpServerFactory = async <
 
   // Start the server (ownApp is guaranteed to exist here — we returned early for external apps)
   if (!ownApp) throw new Error('Expected own Express app');
-  const server = ownApp.listen(PORT, async (error?: Error) => {
+  const onListen = async (error?: Error): Promise<void> => {
     if (error) {
       log.error('Error starting HTTP server:', error);
       exitHandler(1);
     } else {
-      log.info(`HTTP Server listening on port ${PORT}`);
+      log.info(
+        `HTTP Server listening on ${host ? `${host}:${PORT}` : `port ${PORT}`}`,
+      );
       if (inspector) {
         log.info(
           `🌐 MCP inspector running at http://localhost:${PORT}/inspector`,
         );
       }
     }
-  });
+  };
+  // `app.listen` overloads differ by whether a host is provided; calling with
+  // an explicit `undefined` host binds all interfaces (Node's default).
+  const server = host
+    ? ownApp.listen(Number(PORT), host, onListen)
+    : ownApp.listen(PORT, onListen);
   cleanupFns.push(async () => {
     await server.close();
   });


### PR DESCRIPTION
## Summary

Adds optional DNS rebinding protection and network interface binding to the HTTP server, plus a couple of related fixes.

The MCP SDK (already a dependency) bundles `hostHeaderValidation` middleware that guards against [DNS rebinding attacks](https://en.wikipedia.org/wiki/DNS_rebinding). This wires it into `httpServerFactory` behind an opt-in flag, and adds a separate option to control which network interface the server binds to.

## Changes

### DNS rebinding protection (`dnsRebindingProtection`)

- **Opt-in (disabled by default).** This library is primarily used by hosted MCP servers on arbitrary public hostnames, where a Host allow-list would reject legitimate traffic and the DNS rebinding threat (a victim's browser reaching an unauthenticated `localhost` server) does not apply. Localhost/development servers should opt in.
- Enable via `true` (localhost-only, or `MCP_ALLOWED_HOSTS` when set), an explicit `string[]` allow-list, or by setting `MCP_ALLOWED_HOSTS` alone.
- `MCP_ALLOWED_HOSTS` is consulted when the option is omitted or `true`, and ignored for an explicit `string[]` or `false`.
- An explicit `false` always wins over the env var.
- Validation is scoped to the MCP and API mount paths, so callers using an external `app` keep control of their other routes.

Uses the SDK's lower-level `hostHeaderValidation` middleware directly rather than `createMcpExpressApp()`, which would apply `express.json()` globally (breaking the raw-body MCP transport) and doesn't support the external-app mode.

### Interface binding (`host`)

- Optional `host` (default: `HOST` env var) forwarded to `app.listen()`, letting callers restrict the server to e.g. loopback — an OS-level defense independent of `dnsRebindingProtection`.
- Ignored in external-app mode (the caller owns the server lifecycle).

### Fixes

- `server.close()` was incorrectly `await`ed despite returning the `Server` (not a Promise); now promisified so shutdown actually waits for connections to drain.
- Added `PORT` env var validation (allowing `0` for an OS-assigned ephemeral port).

## Testing

- Added `src/httpServer.spec.ts` covering Host header validation (allow/deny, custom allow-list, default-off) and interface binding.
- `tsc`, lint, and all tests pass.
