### PR TITLE
[AGE-513] Add simple cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tigerdata/mcp-boilerplate",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "MCP boilerplate code for Node.js",
   "license": "Apache-2.0",
   "author": "TigerData",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,38 @@
+interface CacheProps<T> {
+  contents?: T;
+  fetch: () => Promise<T[]>;
+  ttl?: number; // amount of time in milliseconds after which cached data will be considered stale
+}
+
+export class Cache<T> {
+  private contents: Promise<T[]> | null = null;
+  private fetch: CacheProps<T>['fetch'];
+  private expirationDateTime?: number;
+
+  constructor({ fetch, ttl }: CacheProps<T>) {
+    this.fetch = fetch;
+
+    if (ttl) {
+      this.expirationDateTime = Date.now() + ttl;
+    }
+  }
+
+  async get(): Promise<T[]> {
+    if (this.expirationDateTime && Date.now() > this.expirationDateTime) {
+      this.contents = null;
+    }
+    this.contents ??= this.fetch();
+
+    return this.contents;
+  }
+
+  async find(predicate: (item: T) => boolean): Promise<T | null> {
+    const items = await this.get();
+    return items.find(predicate) ?? null;
+  }
+
+  async filter(predicate: (item: T) => boolean): Promise<T[]> {
+    const items = await this.get();
+    return items.filter(predicate);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
+export { Cache } from './cache.js';
 export { cliEntrypoint } from './cliEntrypoint.js';
-export { Cache } from './cache.js'
 export { httpServerFactory } from './httpServer.js';
 export { log } from './logger.js';
 export type { AdditionalSetupArgs } from './mcpServer.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { cliEntrypoint } from './cliEntrypoint.js';
+export { Cache } from './cache.js'
 export { httpServerFactory } from './httpServer.js';
 export { log } from './logger.js';
 export type { AdditionalSetupArgs } from './mcpServer.js';


### PR DESCRIPTION
## What
This adds a `Cache<>` object that handles simple caching. This centralizes a common pattern ([github](https://github.com/timescale/tiger-linear-mcp-server/blob/main/src/utils/store.ts), [linear](https://github.com/timescale/tiger-linear-mcp-server/blob/main/src/utils/store.ts)).

Decided to name it `Cache<>` over `Store<>` because there is already a [Store](https://github.com/timescale/mcp-boilerplate-node/blob/a69bc11134fbbe4404b4a9f77acd1f61a9c70a1d/src/migrate.ts#L8) in this repo and `Cache<>` is more explicit.