### PR TITLE
[CHORE] Remove static export on migrate

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "./skills": {
       "import": "./dist/skills/index.js",
       "types": "./dist/skills/index.d.ts"
+    },
+    "./migrate": {
+      "import": "./dist/migrate.js",
+      "types": "./dist/migrate.d.ts"
     }
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ export { cliEntrypoint } from './cliEntrypoint.js';
 export { httpServerFactory } from './httpServer.js';
 export { log } from './logger.js';
 export type { AdditionalSetupArgs } from './mcpServer.js';
-export { createMigrator } from './migrate.js';
 export { registerExitHandlers } from './registerExitHandlers.js';
 export { StatusError } from './StatusError.js';
 export { stdioServerFactory } from './stdio.js';


### PR DESCRIPTION
## What
Remove static export of `createMigrator` -- consumers will import `mcp-boilerplate-node/migrate`

## Why
This static export breaks the conditional load of `migrate.ts`, which causes dependency on peer dependencies pg and migrate. That conditional loading was added here https://github.com/timescale/mcp-boilerplate-node/pull/32/changes#diff-53eba457c23319e8edd836a23d34135c6e59bfba4321095e9b754ead710bd840R19