### PR TITLE
[AGE-516] Fix: Failed to load skill at GitHub path: timescale/eon-skills/.github/SKILL.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tigerdata/mcp-boilerplate",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "MCP boilerplate code for Node.js",
   "license": "Apache-2.0",
   "author": "TigerData",

--- a/src/skills/__fixtures__/collection/.github/SKILL.md
+++ b/src/skills/__fixtures__/collection/.github/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: dot-github-trap
+description: This skill lives in a dot-prefixed directory and must never be loaded by the local_collection loader.
+---
+If this content is ever returned by the skills API, the dot-directory filter is broken.

--- a/src/skills/__fixtures__/collection/real-a/SKILL.md
+++ b/src/skills/__fixtures__/collection/real-a/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: collection-a
+description: First collection skill
+---
+Collection skill A content

--- a/src/skills/__fixtures__/collection/real-b/SKILL.md
+++ b/src/skills/__fixtures__/collection/real-b/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: collection-b
+description: Second collection skill
+---
+Collection skill B content

--- a/src/skills/__fixtures__/skills.yaml
+++ b/src/skills/__fixtures__/skills.yaml
@@ -4,3 +4,6 @@ first-skill:
 second-skill:
   type: local
   path: ./src/skills/__fixtures__/second-skill
+local-collection:
+  type: local_collection
+  path: ./src/skills/__fixtures__/collection

--- a/src/skills/utils.spec.ts
+++ b/src/skills/utils.spec.ts
@@ -19,7 +19,9 @@ describe('Skills API', () => {
   describe('getAvailableSkillNames', () => {
     it('returns a comma-separated list of visible skill names in alphabetical order when skills are loaded', async () => {
       const names = await getAvailableSkillNames({});
-      expect(names).toBe('first-skill, second-skill');
+      expect(names).toBe(
+        'collection-a, collection-b, first-skill, second-skill',
+      );
     });
 
     it('returns "(none)" when flags filter out every skill (e.g. enabledSkills does not match any)', async () => {
@@ -56,11 +58,13 @@ describe('Skills API', () => {
       expect(result).toContain('<available_skills>');
       expect(result).toContain('first-skill');
       expect(result).toContain('second-skill');
+      expect(result).toContain('collection-a');
+      expect(result).toContain('collection-b');
       const inner = result
         .split('<available_skills>')[1]
         .split('</available_skills>')[0];
       const lines = inner.trim().split('\n');
-      expect(lines).toHaveLength(3);
+      expect(lines).toHaveLength(5);
     });
 
     it('read valid skill: returns the content of the skill SKILL.md when name and path are valid', async () => {
@@ -131,6 +135,30 @@ describe('Skills API', () => {
           path: 'SKILL.md\x00.txt',
         }),
       ).rejects.toThrow(InvalidPathError);
+    });
+  });
+
+  describe('local_collection', () => {
+    it('loads every real skill directory inside the collection', async () => {
+      const names = await getAvailableSkillNames({});
+      expect(names).toContain('collection-a');
+      expect(names).toContain('collection-b');
+    });
+
+    it('exposes collection skill content via viewSkillContent', async () => {
+      const result = await viewSkillContent({
+        name: 'collection-a',
+        path: 'SKILL.md',
+      });
+      expect(result).toBe('Collection skill A content\n');
+    });
+
+    it('skips dot-prefixed directories (e.g. .github) even when they contain a valid SKILL.md', async () => {
+      const names = await getAvailableSkillNames({});
+      expect(names).not.toContain('dot-github-trap');
+      await expect(
+        viewSkillContent({ name: 'dot-github-trap', path: 'SKILL.md' }),
+      ).rejects.toBeInstanceOf(SkillNotFoundError);
     });
   });
 });

--- a/src/skills/utils.ts
+++ b/src/skills/utils.ts
@@ -245,6 +245,7 @@ const doLoadSkills = async (
             const flags = parseCollectionFlags(cfg);
             for (const entry of dirEntries) {
               if (entry.isFile()) continue;
+              if (entry.name.startsWith('.')) continue;
               if (!entry.isDirectory()) {
                 log.warn(`Skipping non-directory entry in local_collection`, {
                   path: `${cfg.path}/${entry.name}`,
@@ -306,6 +307,7 @@ const doLoadSkills = async (
             const flags = parseCollectionFlags(cfg);
             for (const entry of dirResponse.data) {
               if (entry.type === 'file') continue;
+              if (entry.name.startsWith('.')) continue;
               if (entry.type !== 'dir') {
                 log.warn(`Skipping non-directory entry in github_collection`, {
                   path: `${cfg.repo}/${entry.path}`,


### PR DESCRIPTION
## Summary
- Fix `local_collection` and `github_collection` skill loaders to skip dot-prefixed directories (e.g. `.github`, `.git`). Previously the loaders enumerated every subdirectory in the collection root and tried to read `<dir>/SKILL.md`; for `.github/` this produced a persistent `log.error("Failed to load skill at GitHub path: timescale/eon-skills/.github/SKILL.md@dev")` on every skills refresh in `tiger-skills-mcp-server` (aws-dev).
- Add a `local_collection` fixture with two real skills plus a `.github/SKILL.md` trap (valid frontmatter, must not be loaded) and three tests that guard the skip.
- Bump `@tigerdata/mcp-boilerplate` from `1.5.2` → `1.5.3`.
The `.github` 404s in Logfire will stop once `tiger-skills-mcp-server` picks up the new version.