### PR TITLE
[CHORE} rename Cache back to Store, add ArrayStore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tigerdata/mcp-boilerplate",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "MCP boilerplate code for Node.js",
   "license": "Apache-2.0",
   "author": "TigerData",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-export { ArrayStore, Store } from './store.js';
 export { cliEntrypoint } from './cliEntrypoint.js';
 export { httpServerFactory } from './httpServer.js';
 export { log } from './logger.js';
@@ -6,6 +5,7 @@ export type { AdditionalSetupArgs } from './mcpServer.js';
 export { registerExitHandlers } from './registerExitHandlers.js';
 export { StatusError } from './StatusError.js';
 export { stdioServerFactory } from './stdio.js';
+export { ArrayStore, Store } from './store.js';
 export { addAiResultToSpan, withSpan } from './tracing.js';
 export type {
   ApiFactory,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { Cache } from './cache.js';
+export { ArrayStore, Store } from './store.js';
 export { cliEntrypoint } from './cliEntrypoint.js';
 export { httpServerFactory } from './httpServer.js';
 export { log } from './logger.js';

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,29 +1,44 @@
-interface CacheProps<T> {
-  contents?: T;
-  fetch: () => Promise<T[]>;
+interface StoreProps<T> {
+  fetch: () => Promise<T>;
   ttl?: number; // amount of time in milliseconds after which cached data will be considered stale
 }
 
-export class Cache<T> {
-  private contents: Promise<T[]> | null = null;
-  private fetch: CacheProps<T>['fetch'];
+export class Store<T> {
+  private contents: Promise<T> | null = null;
+  private fetch: StoreProps<T>['fetch'];
+  private ttl?: number;
   private expirationDateTime?: number;
 
-  constructor({ fetch, ttl }: CacheProps<T>) {
+  constructor({ fetch, ttl }: StoreProps<T>) {
     this.fetch = fetch;
 
     if (ttl) {
+      this.ttl = ttl;
       this.expirationDateTime = Date.now() + ttl;
     }
   }
 
-  async get(): Promise<T[]> {
+  async get(): Promise<T> {
     if (this.expirationDateTime && Date.now() > this.expirationDateTime) {
       this.contents = null;
+      if (this.ttl) {
+        this.expirationDateTime = Date.now() + this.ttl;
+      }
     }
     this.contents ??= this.fetch();
 
     return this.contents;
+  }
+}
+
+interface ArrayStoreProps<T> {
+  fetch: () => Promise<T[]>;
+  ttl?: number;
+}
+
+export class ArrayStore<T> extends Store<T[]> {
+  constructor({ fetch, ttl }: ArrayStoreProps<T>) {
+    super({ fetch, ttl });
   }
 
   async find(predicate: (item: T) => boolean): Promise<T | null> {


### PR DESCRIPTION
## What
This renames the `Cache` object back to `Store` (as it was named in external MCP servers, prior to being added to this repo in this [PR](https://github.com/timescale/mcp-boilerplate-node/pull/41)) and, also, splits out an `ArrayStore`, so that the standard `Store` can have any type of object type. 

Previously, `Cache<T>` would imply that the results from `get()` would be `T[]`. Now, for a `Store`, `get()` will return `T`, but for a `ArrayStore<T>`, `get()` will return `T[]`

## Why
For Tigerlabs functionality, I want to be able to cache a `Record<,>`