### PR TITLE
[CHORE] Switch from bun to npm for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: Setup Node
+        # Node 24 ships npm >= 11.5.1, required for OIDC authentication to npm
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: ./bun ci
       - name: Verify package.json version matches tag
@@ -27,8 +33,7 @@ jobs:
           fi
           echo "package.json version ($package_version) matches tag ($tag_version)"
       - name: Publish to npm
-        # npm 11.5.1 or newer is required for OIDC authentication
-        run: ./bun x "npm@>=11.5.1" publish
+        run: npm publish
   notify-publish:
     name: Notify Publish to Slack
     runs-on: ubuntu-latest


### PR DESCRIPTION
Was running into [error](https://github.com/timescale/mcp-boilerplate-node/actions/runs/29044990068/job/86211777159) whilst deploying. Bun doesn't always include optional NPM packages (e.g. sigstore). Switching to NPM for now.