### PR TITLE
[AGE-538] allow setting the value in the store

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "preset": "recommended"
+      "recommended": true
     }
   },
   "javascript": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tigerdata/mcp-boilerplate",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "MCP boilerplate code for Node.js",
   "license": "Apache-2.0",
   "author": "TigerData",

--- a/src/store.ts
+++ b/src/store.ts
@@ -11,23 +11,28 @@ export class Store<T> {
 
   constructor({ fetch, ttl }: StoreProps<T>) {
     this.fetch = fetch;
-
-    if (ttl) {
-      this.ttl = ttl;
-      this.expirationDateTime = Date.now() + ttl;
-    }
+    this.ttl = ttl;
   }
 
   async get(): Promise<T> {
     if (this.expirationDateTime && Date.now() > this.expirationDateTime) {
       this.contents = null;
-      if (this.ttl) {
-        this.expirationDateTime = Date.now() + this.ttl;
-      }
+      this.expirationDateTime = undefined;
     }
     this.contents ??= this.fetch();
 
+    if (this.ttl && !this.expirationDateTime) {
+      this.expirationDateTime = Date.now() + this.ttl;
+    }
+
     return this.contents;
+  }
+
+  set(value: T): void {
+    this.contents = Promise.resolve(value);
+    if (this.ttl) {
+      this.expirationDateTime = Date.now() + this.ttl;
+    }
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,8 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "declaration": true,
+    "sourceMap": true,
+    "inlineSources": true,
     "types": ["bun", "node"]
   },
   "include": ["./src/**/*.ts"],


### PR DESCRIPTION
## What
* add a `set()` on the `Store<>` so that its value can be dynamically updated.
* fix biome v2 format on config file
* simplify TTL logic on store

## Why
Planning on dynamic updating of MCP servers in [tigerlabs](https://github.com/timescale/tigerlabs), which will require pushing a new value to the store.