### PR TITLE
add zDateRangeInclude and zFlexibleDate as factory functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ export { log } from './logger.js';
 export type { AdditionalSetupArgs } from './mcpServer.js';
 export { registerExitHandlers } from './registerExitHandlers.js';
 export { StatusError } from './StatusError.js';
+export type { DateRangeInclude } from './schemas.js';
+export { zDateRangeInclude, zFlexibleDate } from './schemas.js';
 export { stdioServerFactory } from './stdio.js';
 export { ArrayStore, Store } from './store.js';
 export { addAiResultToSpan, withSpan } from './tracing.js';
@@ -16,5 +18,3 @@ export type {
   PromptFactory,
   ResourceFactory,
 } from './types.js';
-export { zDateRangeInclude, zFlexibleDate } from './schemas.js';
-export type { DateRangeInclude } from './schemas.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,5 @@ export type {
   PromptFactory,
   ResourceFactory,
 } from './types.js';
+export { zDateRangeInclude, zFlexibleDate } from './schemas.js';
+export type { DateRangeInclude } from './schemas.js';

--- a/src/schemas.spec.ts
+++ b/src/schemas.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { toJsonSchemaCompat } from '@modelcontextprotocol/sdk/server/zod-json-schema-compat';
+import { toJsonSchemaCompat } from '@modelcontextprotocol/sdk/server/zod-json-schema-compat.js';
 import { z } from 'zod';
 import { zDateRangeInclude } from './schemas.js';
 

--- a/src/schemas.spec.ts
+++ b/src/schemas.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test';
+import { toJsonSchemaCompat } from '@modelcontextprotocol/sdk/server/zod-json-schema-compat';
+import { z } from 'zod';
+import { zDateRangeInclude } from './schemas.js';
+
+/**
+ * Verify that zDateRangeInclude (a factory function) produces JSON Schema
+ * with zero $ref references. Several LLM providers (e.g. Moonshot/Kimi K3)
+ * reject $ref pointers that don't start with "#/$defs/", so this is a hard
+ * compatibility requirement.
+ */
+describe('zDateRangeInclude JSON Schema', () => {
+  const inputSchema = {
+    includeInvoices: zDateRangeInclude().describe('include invoices'),
+    includeStripePayments: zDateRangeInclude().describe(
+      'include stripe payments',
+    ),
+  };
+
+  const jsonSchema = toJsonSchemaCompat(z.object(inputSchema));
+
+  it('contains zero $ref references (LLM provider compatibility)', () => {
+    const serialized = JSON.stringify(jsonSchema);
+    const matches = [...serialized.matchAll(/"\$ref"/g)];
+    expect(matches.length).toBe(0);
+  });
+
+  it('each call returns a distinct instance (no shared identity)', () => {
+    const a = zDateRangeInclude();
+    const b = zDateRangeInclude();
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+/**
+ * Accept any date string that `new Date(...)` can parse (ISO 8601, RFC 2822,
+ * "YYYY-MM-DD", etc.), then normalize to an ISO 8601 string. This is friendlier
+ * than z.string().datetime(), which rejects common shapes like "2024-01-01".
+ *
+ * Returns a fresh Zod type instance on every call so that zod-to-json-schema
+ * never emits a $ref pointer — several LLM providers (e.g. Moonshot/Kimi K3)
+ * reject JSON Schema $ref references that don't start with "#/$defs/".
+ */
+export const zFlexibleDate = () =>
+  z.string().transform((s, ctx) => {
+    const d = new Date(s);
+    if (Number.isNaN(d.getTime())) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Invalid date: "${s}"`,
+      });
+      return z.NEVER;
+    }
+    return d.toISOString();
+  });
+
+/**
+ * A nullable date-range object with `rangeStart` and `rangeEnd`, each
+ * accepting any parseable date string (see {@link zFlexibleDate}).
+ *
+ * Returns a fresh Zod type instance on every call so that zod-to-json-schema
+ * never emits a $ref pointer — several LLM providers (e.g. Moonshot/Kimi K3)
+ * reject JSON Schema $ref references that don't start with "#/$defs/".
+ */
+export const zDateRangeInclude = () =>
+  z
+    .object({
+      rangeStart: zFlexibleDate()
+        .nullable()
+        .describe(
+          'Inclusive start of the range. Accepts any parseable date string (e.g. "2024-01-01" or "2024-01-01T00:00:00Z"). Null to use the default window.',
+        ),
+      rangeEnd: zFlexibleDate()
+        .nullable()
+        .describe(
+          'Inclusive end of the range. Accepts any parseable date string (e.g. "2024-01-01" or "2024-01-01T00:00:00Z"). Null for "up to now".',
+        ),
+    })
+    .nullable();
+
+/** The TypeScript type for a {@link zDateRangeInclude} value. */
+export type DateRangeInclude = z.infer<ReturnType<typeof zDateRangeInclude>>;


### PR DESCRIPTION
zod-to-json-schema emits  pointers when a Zod schema instance is reused across multiple fields. Several LLM providers (e.g. Moonshot/Kimi K3) reject  values that don't start with "#/\/", breaking tool use for any MCP server that shares a Zod singleton across parameters.

These factory functions return a fresh instance on every call so the generated JSON Schema is always inlined — zero  references. Downstream MCP servers can import them instead of defining their own, avoiding a class of compatibility bugs that are hard to diagnose.

See: https://github.com/modelcontextprotocol/typescript-sdk/pull/1563
     https://github.com/modelcontextprotocol/typescript-sdk/issues/2100

We initially took at a stab at fixing a very specific issue we saw around the billing MCP in this PR
https://github.com/timescale/tiger-billing-mcp-server/pull/7

But changing it here will get ahead of any other MCPs that end up implementing a similar pattern. This does not however change any future schema changes that result in references. If it becomes an issue we might have to think of a broader fix.